### PR TITLE
Add staking contract with ERC-20 liquid staking token

### DIFF
--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -5,10 +5,8 @@ import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
-
-
-contract LiquidToken is ERC20, Ownable {
-    constructor(address initialOwner) ERC20("Liquid Staking Token", "LST") Ownable(initialOwner) {}
+contract DPNToken is ERC20, Ownable {
+    constructor(address initialOwner) ERC20("Decentralized Proof of Network", "DPN") Ownable(initialOwner) {}
 
     // Only the owner (Staking contract) can call the mint function
     function mint(address to, uint256 amount) external onlyOwner {
@@ -17,33 +15,54 @@ contract LiquidToken is ERC20, Ownable {
 }
 
 contract Staking is Ownable, ReentrancyGuard {
-    LiquidToken public liquidToken;
+    DPNToken public dpnToken;
     mapping(address => uint256) public stakedETH;
+    address[] public stakers;
 
     event Stake(address indexed user, uint256 amount);
     event Redeem(address indexed user, uint256 amount);
 
     constructor() Ownable(msg.sender) {
-        liquidToken = new LiquidToken(address(this));
-        liquidToken.transferOwnership(address(this)); // Transfer minting rights to the Staking contract
+        dpnToken = new DPNToken(address(this));
+        dpnToken.transferOwnership(address(this)); // Transfer minting rights to the Staking contract
     }
 
     function stakeETH() external payable {
         require(msg.value > 0, "Cannot stake 0 ETH");
+
+        if (stakedETH[msg.sender] == 0) {
+            stakers.push(msg.sender); // Add the staker if they are staking for the first time.
+        }
+
         stakedETH[msg.sender] += msg.value;
-        liquidToken.mint(msg.sender, msg.value); // Mint 1 LST per 1 staked ETH
+        dpnToken.mint(msg.sender, msg.value); // Mint 1 DPN per 1 staked ETH
 
         emit Stake(msg.sender, msg.value);
+    }
+
+    function distributeRewards(uint256 rewardAmount) external onlyOwner {
+        require(address(this).balance >= rewardAmount, "Not enough ETH in contract");
+        require(rewardAmount > 0, "Reward amount must be greater than 0");
+
+        uint256 totalStaked = address(this).balance - rewardAmount; // Total ETH staked by users.
+        require(totalStaked > 0, "No staked ETH available for rewards");
+
+        // Distribute rewards proportionally to each staker based on their share of total staked ETH.
+        for (uint256 i = 0; i < stakers.length; i++) {
+            address staker = stakers[i];
+            uint256 stakerShare = (stakedETH[staker] * rewardAmount) / totalStaked;
+            stakedETH[staker] += stakerShare;
+        }
     }
 
     function redeemETH(uint256 _amount) external nonReentrant {
         require(stakedETH[msg.sender] >= _amount, "Insufficient balance");
         stakedETH[msg.sender] -= _amount;
 
-        // The user must approve the transfer of LST to the staking contract
+        // The user must approve the transfer of DPN to the staking contract
         require(
-            liquidToken.transferFrom(msg.sender, address(this), _amount),
-            "Transfer of LST failed. Ensure you have approved the contract."
+            dpnToken.transferFrom(msg.sender, address(this), _amount),
+            "Transfer of DPN failed. Ensure you have approved the contract."
         );
 
         payable(msg.sender).transfer(_amount);


### PR DESCRIPTION
    3. Implement Liquid Staking Logic:
        ◦ Ensure the contract can handle staking ETH on the testnet and track the staked amount.
        ◦ Implement logic to calculate and distribute staking rewards to the liquid staking token holders.
    4. Redeeming Staked ETH:
        ◦ Add functionality to allow users to redeem their staked ETH by burning their liquid staking tokens.
        ◦ Ensure the contract properly handles the unstaking process and returns ETH to the user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new token, "Decentralized Proof of Network" (DPN), replacing the previous Liquid Staking Token (LST).
	- Added a reward distribution function for proportional ETH rewards to stakers.
  
- **Bug Fixes**
	- Updated functions to ensure correct token handling and error messaging related to the new DPN token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->